### PR TITLE
[DO NOT MERGE][DEBUG] - Investigating decode time equal to zero

### DIFF
--- a/config/manager/configmap.yaml
+++ b/config/manager/configmap.yaml
@@ -12,7 +12,7 @@ data:
   # - General: "https://prometheus:9090"
   # - OpenShift: "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"
   # - KIND cluster: "https://kube-prometheus-stack-prometheus.workload-variant-autoscaler-monitoring.svc.cluster.local:9090"
-  PROMETHEUS_BASE_URL: "https://kube-prometheus-stack-prometheus.workload-variant-autoscaler-monitoring.svc.cluster.local:9090"
+  PROMETHEUS_BASE_URL: "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"
   
   # TLS Configuration (TLS is always enabled for HTTPS-only support)
   # PROMETHEUS_TLS_INSECURE_SKIP_VERIFY: "true"  # Skip certificate verification (development/testing only)

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -64,7 +64,7 @@ spec:
           - --leader-elect=true
           - --health-probe-bind-address=:8081
         image: controller:latest
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         env:
           - name: LOG_LEVEL
             value: "debug"  # or "info", "warn", "error"

--- a/hack/inferno/pkg/analyzer/queueanalyzer.go
+++ b/hack/inferno/pkg/analyzer/queueanalyzer.go
@@ -2,6 +2,8 @@ package analyzer
 
 import (
 	"fmt"
+
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/logger"
 )
 
 // small disturbance around a value
@@ -86,9 +88,11 @@ type TargetRate struct {
 // create a new queue analyzer from config
 func NewQueueAnalyzer(qConfig *Configuration, requestSize *RequestSize) (*QueueAnalyzer, error) {
 	if err := qConfig.check(); err != nil {
+		logger.Log.Debug("DELETE ME - ", "err ", err)
 		return nil, err
 	}
 	if err := requestSize.check(); err != nil {
+		logger.Log.Debug("DELETE ME - ", "err ", err)
 		return nil, err
 	}
 	// build queueing model
@@ -98,12 +102,21 @@ func NewQueueAnalyzer(qConfig *Configuration, requestSize *RequestSize) (*QueueA
 // build queueing model using service rates, leaving arrival rate as parameter
 func BuildModel(qConfig *Configuration, requestSize *RequestSize) (modelData *QueueAnalyzer) {
 	parms := qConfig.ServiceParms
+	logger.Log.Debug("DELETE ME - ", "params ", parms)
+	logger.Log.Debug("DELETE ME - ", "params ", parms)
 
 	// calculate state-dependent service rate
 	servRate := make([]float32, qConfig.MaxBatchSize)
 	for n := 1; n <= qConfig.MaxBatchSize; n++ {
 		prefillTime := parms.Prefill.PrefillTime(requestSize.AvgInputTokens, float32(n))
 		decodeTime := float32(requestSize.AvgOutputTokens-1) * parms.Decode.DecodeTime(float32(n))
+		logger.Log.Debug("DELETE ME - ", "decodeTime ", decodeTime)
+		logger.Log.Debug("DELETE ME - ", "prefillTime ", prefillTime)
+		if prefillTime+decodeTime == 0 {
+			decodeTime = 1.0
+			logger.Log.Warn("DELETE ME - ", "division by zero ; decodeTime ", decodeTime)
+
+		}
 		servRate[n-1] = float32(n) / (prefillTime + decodeTime)
 	}
 

--- a/hack/inferno/pkg/core/allocation.go
+++ b/hack/inferno/pkg/core/allocation.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/logger"
+
 	"github.com/llm-d-incubation/workload-variant-autoscaler/hack/inferno/pkg/analyzer"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/hack/inferno/pkg/config"
 )
@@ -47,10 +49,14 @@ func CreateAllocation(serverName string, gName string) *Allocation {
 	if server = GetServer(serverName); server == nil {
 		return nil
 	}
+	logger.Log.Debug("DELETE ME ", "serverName: ", serverName, " accelerator: ", gName, " load: ", load)
 	if load = server.Load(); load == nil || load.ArrivalRate < 0 ||
 		load.AvgInTokens < 0 || load.AvgOutTokens < 0 {
+		logger.Log.Debug("DELETE ME - invalid server load - ", "serverName: ", serverName, " accelerator: ", gName, " load: ", load)
 		return nil
 	}
+
+	logger.Log.Debug("DELETE ME - ", "serverName: ", serverName, " accelerator: ", gName, " load: ", load)
 
 	// get model info
 	modelName := server.ModelName()
@@ -76,14 +82,19 @@ func CreateAllocation(serverName string, gName string) *Allocation {
 
 	// calculate max batch size (N) based on average request length (K)
 	K := load.AvgOutTokens
+	logger.Log.Debug("DELETE ME - ", "serverName: ", serverName, " accelerator: ", gName, " load: ", load, " AvgOutTokens: ", K)
 
 	// use maxBatchSize from configured value or scaled performance data
 	var N int
 	if server.maxBatchSize > 0 {
 		N = server.maxBatchSize
+		logger.Log.Debug("DELETE ME - ", "serverName: ", serverName, " accelerator: ", gName, " load: ", load, " MaxBatchSize: ", server.maxBatchSize)
 	} else {
+		logger.Log.Debug("DELETE ME - ", "serverName: ", serverName, " accelerator: ", gName, " load: ", load, " perfAtTTokens: ", perf.AtTokens, " perfBatch: ", perf.MaxBatchSize)
 		N = max(perf.MaxBatchSize*perf.AtTokens/K, 1)
+
 	}
+	logger.Log.Debug("DELETE ME - ", "serverName: ", serverName, " accelerator: ", gName, " load: ", load, " MaxBatchSize: ", N)
 	maxQueue := N * config.MaxQueueToBatchRatio
 
 	// create queue analyzer
@@ -101,6 +112,7 @@ func CreateAllocation(serverName string, gName string) *Allocation {
 			},
 		},
 	}
+	logger.Log.Debug("DELETE ME - ", "queueAnalyzer config: ", qConfig)
 
 	requestData := &analyzer.RequestSize{
 		AvgInputTokens:  load.AvgInTokens,

--- a/hack/inferno/pkg/core/server.go
+++ b/hack/inferno/pkg/core/server.go
@@ -3,6 +3,8 @@ package core
 import (
 	"fmt"
 
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/logger"
+
 	"github.com/llm-d-incubation/workload-variant-autoscaler/hack/inferno/pkg/config"
 )
 
@@ -56,9 +58,12 @@ func (s *Server) Calculate(accelerators map[string]*Accelerator) {
 	candidateAccelerators := s.GetCandidateAccelerators(accelerators)
 	s.allAllocations = make(map[string]*Allocation)
 	for _, g := range candidateAccelerators {
-		if alloc := CreateAllocation(s.name, g.Name()); alloc != nil {
+		alloc := CreateAllocation(s.name, g.Name())
+		logger.Log.Debug("DELETE ME - ", "modelAnalyzer: ", alloc)
+		if alloc != nil {
 			if s.curAllocation != nil {
 				penalty := s.curAllocation.TransitionPenalty(alloc)
+				logger.Log.Debug("DELETE ME - penalty calculated - ", "penalty: ", penalty)
 				alloc.SetValue(penalty)
 			}
 			s.allAllocations[g.Name()] = alloc
@@ -69,6 +74,7 @@ func (s *Server) Calculate(accelerators map[string]*Accelerator) {
 // Create a subset of candidate accelerators for a server from a given set
 func (s *Server) GetCandidateAccelerators(accelerators map[string]*Accelerator) map[string]*Accelerator {
 	if s.keepAccelerator {
+		logger.Log.Debug("DELETE ME - currAlloc: ", s.curAllocation, "accelerator: ", s.curAllocation.accelerator)
 		if s.curAllocation != nil && s.curAllocation.accelerator != "" {
 			accMap := make(map[string]*Accelerator)
 			curAccName := s.curAllocation.accelerator
@@ -77,6 +83,7 @@ func (s *Server) GetCandidateAccelerators(accelerators map[string]*Accelerator) 
 			}
 			return accMap
 		}
+		logger.Log.Warn("keepAccelerator is set but current allocation or accelerator is nil - ", "server-name: ", s.name)
 	}
 	return accelerators
 }

--- a/internal/controller/variantautoscaling_controller.go
+++ b/internal/controller/variantautoscaling_controller.go
@@ -229,8 +229,9 @@ func (r *VariantAutoscalingReconciler) prepareVariantAutoscalings(
 		logger.Log.Info("Found SLO for model - ", "model: ", modelName, ", class: ", className, ", slo-tpot: ", entry.SLOTPOT, ", slo-ttft: ", entry.SLOTTFT)
 
 		for _, modelAcceleratorProfile := range va.Spec.ModelProfile.Accelerators {
-			if utils.AddModelAcceleratorProfileToSystemData(systemData, modelName, &modelAcceleratorProfile) != nil {
-				logger.Log.Error("variantAutoscaling bad model accelerator profile data, skipping optimization - ", "variantAutoscaling-name: ", va.Name)
+			err := utils.AddModelAcceleratorProfileToSystemData(systemData, modelName, &modelAcceleratorProfile)
+			if err != nil {
+				logger.Log.Error(err, "variantAutoscaling bad model accelerator profile data, skipping optimization - ", "variantAutoscaling-name: ", va.Name)
 				continue
 			}
 		}
@@ -243,7 +244,7 @@ func (r *VariantAutoscalingReconciler) prepareVariantAutoscalings(
 		}
 		acceleratorCostValFloat, err := strconv.ParseFloat(acceleratorCostVal, 32)
 		if err != nil {
-			logger.Log.Error("variantAutoscaling unable to parse accelerator cost in configMap, skipping optimization - ", "variantAutoscaling-name: ", va.Name)
+			logger.Log.Error(err, "variantAutoscaling unable to parse accelerator cost in configMap, skipping optimization - ", "variantAutoscaling-name: ", va.Name)
 			continue
 		}
 
@@ -269,7 +270,7 @@ func (r *VariantAutoscalingReconciler) prepareVariantAutoscalings(
 		updateVA.Status.CurrentAlloc = currentAllocation
 
 		if err := utils.AddServerInfoToSystemData(systemData, &updateVA, className); err != nil {
-			logger.Log.Info("variantAutoscaling bad deployment server data, skipping optimization - ", "variantAutoscaling-name: ", updateVA.Name)
+			logger.Log.Info(err, "variantAutoscaling bad deployment server data, skipping optimization - ", "variantAutoscaling-name: ", updateVA.Name)
 			continue
 		}
 

--- a/internal/modelanalyzer/analyzer.go
+++ b/internal/modelanalyzer/analyzer.go
@@ -6,6 +6,7 @@ import (
 	llmdOptv1alpha1 "github.com/llm-d-incubation/workload-variant-autoscaler/api/v1alpha1"
 	inferno "github.com/llm-d-incubation/workload-variant-autoscaler/hack/inferno/pkg/core"
 	interfaces "github.com/llm-d-incubation/workload-variant-autoscaler/internal/interfaces"
+	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/logger"
 	"github.com/llm-d-incubation/workload-variant-autoscaler/internal/utils"
 )
 
@@ -26,9 +27,13 @@ func (ma *ModelAnalyzer) AnalyzeModel(ctx context.Context,
 	va llmdOptv1alpha1.VariantAutoscaling) *interfaces.ModelAnalyzeResponse {
 
 	serverName := utils.FullName(va.Name, va.Namespace)
+	logger.Log.Debug("DELETE ME - ", "Analyzing model for serverName - : ", serverName)
 	if server, exists := ma.system.Servers()[serverName]; exists {
+		logger.Log.Debug("DELETE ME - Found server in system - ", server.Name())
 		server.Calculate(ma.system.Accelerators())
+		logger.Log.Debug("DELETE ME - serverAlloc - ", server.AllAllocations())
 		return CreateModelAnalyzeResponseFromAllocations(server.AllAllocations())
 	}
+	logger.Log.Debug("DELETE ME - ModelAnalyzer unable to find server in system, skipping optimization - ", "variantAutoscaling-name: ", va.Name)
 	return &interfaces.ModelAnalyzeResponse{}
 }


### PR DESCRIPTION
**Issue**
By launching GuideLLM with the following configuration:

```bash
guidellm benchmark --target "http://localhost:8000" --rate-type "constant" --rate 16  --max-seconds 300 --model "unsloth/Meta-Llama-3.1-8B" --data Infinity-Instruct-7M.csv
```

An unexpected division by zero was triggered in the Queue Analyzer [`queueanalyzer.go:120`]:
```go
func BuildModel(qConfig *Configuration, requestSize *RequestSize) (modelData *QueueAnalyzer) {
	parms := qConfig.ServiceParms
	servRate := make([]float32, qConfig.MaxBatchSize)
	for n := 1; n <= qConfig.MaxBatchSize; n++ {
		prefillTime := parms.Prefill.PrefillTime(requestSize.AvgInputTokens, float32(n))
		decodeTime := float32(requestSize.AvgOutputTokens-1) * parms.Decode.DecodeTime(float32(n))
		servRate[n-1] = float32(n) / (prefillTime + decodeTime) // <-- here
	}
...
}
```

This was caused by the `AvgOutputTokens` to be equal to 1. 


**Reproducing this issue**
Build and deploy a new image from this PR, or use an existing one on `quay.io/tomsgre/infernoautoscaler:debug`.
After setting up `llm-d`, the WVA ConfigMaps and the VariantAutoscaling CR, launch GuideLLM with the specified configuration.