### PR TITLE
Update QuickStart documentation to disable Rosetta on Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Modeling and optimization techniques used in the workload-variant-autoscaler are
 
 ## Quickstart Guide: Installation of workload-variant-autoscaler along with llm-d infrastructure emulated deployment on a Kind cluster
 
+_Note: If you are on a Mac with Apple Silicon, please disable Rosetta. See [this issue](https://github.com/llm-d-incubation/workload-variant-autoscaler/issues/181) for details._
+
 Use this target to spin up a local test environment integrated with llm-d core components:
 
 ```sh


### PR DESCRIPTION
While running QuickStart Kind workflow on Mac with Apple Silicon, if Rosetta is on (which is on by default on Docker Desktop), `infra-sim-inference-gateway` pod gets stuck in CrashLoopBackoff. The failing pod's container uses multi-arch `envoy-wrapper:v2.0.3` image.

Disabling Rosetta avoids this CrashLoopBackoff issue. The PR aims to add documentation to QuickStart to disable Rosetta so that future users get to a working setup quickly instead of trying to debug a very interesting CrashLoopBackoff. Please see [issue 181](https://github.com/llm-d-incubation/workload-variant-autoscaler/issues/181) for details on the Rosetta failure.